### PR TITLE
fix: resolver alertas de seguridad npm en las tres apps (notas, notas_auth, libros)

### DIFF
--- a/libros/package-lock.json
+++ b/libros/package-lock.json
@@ -1,21 +1,22 @@
 {
-    "name": "dependabot_20260728-909-uikpvc",
+    "name": "libros",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "devDependencies": {
-                "axios": "^0.21",
+                "axios": "^0.33",
                 "bootstrap": "^4.0.0",
                 "cross-env": "^7.0",
                 "jquery": "^3.2",
                 "laravel-mix": "^6.0.49",
-                "lodash": "^4.17.21",
+                "lodash": "^4.18.0",
                 "popper.js": "^1.12",
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.15.2",
                 "sass-loader": "^8.0.0",
-                "vue-template-compiler": "^2.6.11"
+                "vue-template-compiler": "^2.6.11",
+                "webpack": "5.104.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1798,6 +1799,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1835,6 +1849,259 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.3.tgz",
+            "integrity": "sha512-N3POfw5RA7efAliAATiudtmvKQqukVEOzrMQuqQY/us2EPKczMy2WiecLt1SX6s3b0OwcFaPUXGF6uIYlBUTbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.3.tgz",
+            "integrity": "sha512-E9zYmC5mk7eiDKqQAOsZGrJ7mUCIDC0031s4Nsl7dj1Za5EBKcHVqY+1vD/a4xbk480PGqvi455W2b4FeHRJ8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.3.tgz",
+            "integrity": "sha512-4xmeZiZ46VI2qGbiZPzdv6p9IhMtjWdbwZf3VCgN8OAVcued60ej5Ki2FF94srVH4Ot/h45Co7T5C/fpQXP4rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.3.tgz",
+            "integrity": "sha512-Nzwoj+fRr1XB9CQuc4AanUuvQ3OIXAY+ngZIYP+eZUqd+Sonj+ZHTnrg+egQuUJ64/iMi9HFPN04MokGrFTK0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-rsa": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.3.tgz",
+            "integrity": "sha512-ecGZpkY6Lq5bSgTFU+LS74WjawzDgjWHcjFMVNPH/1C0j53Xi9dmLcPMdmZyk8gdsd2RKeV1fP9EbLB6W6zZ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.3.tgz",
+            "integrity": "sha512-yjWVrQEmPp2y9lWjLLE28BRHbt7wYdwWvwXjFgNuekP9mDD/ofz31muVI8qOg2as7XZs1bZIZGPPnJ/0osTClQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pfx": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.3.tgz",
+            "integrity": "sha512-t7m3e9p/Gf9YoMM+hLsHUqB+NhOlifiOkENAIG4RV2BFWVGTATVzbXoR8L0EgNWpiriPaeIjBCS5B9PTtkaxQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.3.tgz",
+            "integrity": "sha512-SOux4+jikCnOwoJvpBp/grOqzFmJPnNSwe3sAg1Bn93YdmCiDtvolZifJIhiRq0UWMTnLRPj9/ZCMAc2W9VsMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.3.tgz",
+            "integrity": "sha512-HE+ejy9dX9JP3yLL6CGYoWym4Cted1lGXH7DxsbNDGiq8KabwVR7mzYidwsyNZ/m0hNWjiS+dzSwrsgMB/OIaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.3.tgz",
+            "integrity": "sha512-v5Oa6p7hCT3ONqYHQyTFQYcycD06eMhHbr0m7evpvPQSpWJIq8GgbdnvA9bVGTUlOx6KOeDrX7Z0W4s/yboNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@peculiar/x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1932,6 +2199,28 @@
             "dependencies": {
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -2090,16 +2379,6 @@
                 "undici-types": "~8.3.0"
             }
         },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -2122,9 +2401,9 @@
             "license": "MIT"
         },
         "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true,
             "license": "MIT"
         },
@@ -2449,6 +2728,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
+            }
+        },
         "node_modules/adjust-sourcemap-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -2626,6 +2918,28 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/assert": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -2650,6 +2964,13 @@
             "dependencies": {
                 "inherits": "2.0.1"
             }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/autoprefixer": {
             "version": "10.5.4",
@@ -2705,12 +3026,15 @@
             }
         },
         "node_modules/axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.33.0.tgz",
+            "integrity": "sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.10.0"
+                "follow-redirects": "^1.15.4",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/babel-loader": {
@@ -2856,10 +3180,11 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-            "dev": true
+            "version": "4.12.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+            "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "1.20.6",
@@ -3171,6 +3496,22 @@
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3179,6 +3520,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/call-bind": {
@@ -3358,14 +3709,40 @@
             }
         },
         "node_modules/cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
+        },
+        "node_modules/cipher-base/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/clean-css": {
             "version": "5.3.3",
@@ -3465,6 +3842,19 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/commander": {
             "version": "7.2.0",
@@ -4096,17 +4486,34 @@
                 }
             }
         },
-        "node_modules/default-gateway": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+        "node_modules/default-browser": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "execa": "^5.0.0"
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/define-data-property": {
@@ -4128,13 +4535,26 @@
             }
         },
         "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/depd": {
@@ -4393,12 +4813,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4507,6 +4921,22 @@
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4621,30 +5051,6 @@
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/express": {
@@ -4979,9 +5385,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.8",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-            "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -4989,6 +5395,7 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -5012,6 +5419,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -5062,13 +5486,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/fs-monkey": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-            "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-            "dev": true,
-            "license": "Unlicense"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -5160,19 +5577,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5207,6 +5611,13 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/globby": {
             "version": "10.0.2",
@@ -5413,23 +5824,6 @@
                 "readable-stream": "^2.0.1",
                 "wbuf": "^1.1.0"
             }
-        },
-        "node_modules/html-entities": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/mdevils"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://patreon.com/mdevils"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/html-loader": {
             "version": "1.3.2",
@@ -5662,14 +6056,14 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
             "dev": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "engines": {
-                "node": ">=10.17.0"
+                "node": ">=10.18"
             }
         },
         "node_modules/iconv-lite": {
@@ -5925,6 +6319,54 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+            "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5958,19 +6400,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-typed-array": {
@@ -6252,11 +6681,26 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -6264,18 +6708,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/locate-path": {
@@ -6292,10 +6724,11 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -6422,17 +6855,520 @@
             }
         },
         "node_modules/memfs": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-            "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+            "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
             "dev": true,
-            "license": "Unlicense",
+            "license": "Apache-2.0",
             "dependencies": {
-                "fs-monkey": "^1.0.4"
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/buffers": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+            "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
             },
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
             }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+            "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+            "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+            "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+            "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+            "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "glob-to-regex.js": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+            "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+            "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/thingies": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "node_modules/memfs/node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.3",
@@ -6544,16 +7480,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/mini-css-extract-plugin": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
@@ -6645,130 +7571,6 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "dev": true
-        },
-        "node_modules/minimizer-webpack-plugin": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@minify-html/node": {
-                    "optional": true
-                },
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/css": {
-                    "optional": true
-                },
-                "@swc/html": {
-                    "optional": true
-                },
-                "clean-css": {
-                    "optional": true
-                },
-                "cssnano": {
-                    "optional": true
-                },
-                "csso": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "html-minifier-terser": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "postcss": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6843,16 +7645,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
-        },
-        "node_modules/node-forge": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
         },
         "node_modules/node-libs-browser": {
             "version": "2.2.1",
@@ -6938,19 +7730,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -7025,35 +7804,20 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7108,17 +7872,21 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/retry": "0.12.0",
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -7382,6 +8150,31 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/pkijs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/popper.js": {
             "version": "1.16.1",
@@ -8079,6 +8872,13 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -8100,6 +8900,33 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/pvutils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+            "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/qs": {
@@ -8245,6 +9072,13 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -8466,23 +9300,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/ripemd160": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
@@ -8495,6 +9312,19 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -8630,17 +9460,17 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -8993,13 +9823,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9189,16 +10012,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/style-loader": {
@@ -9586,6 +10399,19 @@
             "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
             "dev": true
         },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -9780,14 +10606,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vary": {
@@ -9851,32 +10680,37 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.109.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.1.tgz",
-            "integrity": "sha512-Q4XQscWSLNQSaMFsIWUZ+IVpvwLqD+MvjIuSQC1hG8m1ZMK78VAsNMhTjD3icJelypp6aM5Hq8BZNEX3sc1PJw==",
+            "version": "5.104.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.2",
-                "es-module-lexer": "^2.1.0",
+                "enhanced-resolve": "^5.17.4",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.6.1",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.3.1",
+                "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -9943,27 +10777,33 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
@@ -10003,6 +10843,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -10024,55 +10881,53 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.25",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "default-gateway": "^6.0.3",
-                "express": "^4.17.3",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.14.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.4",
-                "ws": "^8.13.0"
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -10081,6 +10936,19 @@
                 "webpack-cli": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/webpack-dev-server/node_modules/ajv": {
@@ -10383,6 +11251,38 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/xtend": {

--- a/libros/package.json
+++ b/libros/package.json
@@ -10,16 +10,27 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.21",
+        "axios": "^0.33",
         "bootstrap": "^4.0.0",
         "cross-env": "^7.0",
         "jquery": "^3.2",
         "laravel-mix": "^6.0.49",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "popper.js": "^1.12",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0",
-        "vue-template-compiler": "^2.6.11"
+        "vue-template-compiler": "^2.6.11",
+        "webpack": "5.104.1"
+    },
+    "overrides": {
+        "webpack-dev-server": "^5.2.6",
+        "json5": "^2.2.3",
+        "loader-utils": "^1.4.2",
+        "fast-uri": "^3.1.5",
+        "uuid": "^11.1.1",
+        "cipher-base": "^1.0.5",
+        "follow-redirects": "^1.16.0",
+        "bn.js": "^4.12.3"
     }
 }

--- a/notas/package-lock.json
+++ b/notas/package-lock.json
@@ -1,17 +1,18 @@
 {
-    "name": "dependabot_20260728-909-nzc242",
+    "name": "notas",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "devDependencies": {
-                "axios": "^0.21",
+                "axios": "^0.33",
                 "cross-env": "^7.0",
                 "laravel-mix": "^6.0.49",
-                "lodash": "^4.17.21",
+                "lodash": "^4.18.0",
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.15.2",
-                "sass-loader": "^8.0.0"
+                "sass-loader": "^8.0.0",
+                "webpack": "5.104.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1794,6 +1795,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1831,6 +1845,259 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.3.tgz",
+            "integrity": "sha512-N3POfw5RA7efAliAATiudtmvKQqukVEOzrMQuqQY/us2EPKczMy2WiecLt1SX6s3b0OwcFaPUXGF6uIYlBUTbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.3.tgz",
+            "integrity": "sha512-E9zYmC5mk7eiDKqQAOsZGrJ7mUCIDC0031s4Nsl7dj1Za5EBKcHVqY+1vD/a4xbk480PGqvi455W2b4FeHRJ8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.3.tgz",
+            "integrity": "sha512-4xmeZiZ46VI2qGbiZPzdv6p9IhMtjWdbwZf3VCgN8OAVcued60ej5Ki2FF94srVH4Ot/h45Co7T5C/fpQXP4rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.3.tgz",
+            "integrity": "sha512-Nzwoj+fRr1XB9CQuc4AanUuvQ3OIXAY+ngZIYP+eZUqd+Sonj+ZHTnrg+egQuUJ64/iMi9HFPN04MokGrFTK0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-rsa": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.3.tgz",
+            "integrity": "sha512-ecGZpkY6Lq5bSgTFU+LS74WjawzDgjWHcjFMVNPH/1C0j53Xi9dmLcPMdmZyk8gdsd2RKeV1fP9EbLB6W6zZ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.3.tgz",
+            "integrity": "sha512-yjWVrQEmPp2y9lWjLLE28BRHbt7wYdwWvwXjFgNuekP9mDD/ofz31muVI8qOg2as7XZs1bZIZGPPnJ/0osTClQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pfx": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.3.tgz",
+            "integrity": "sha512-t7m3e9p/Gf9YoMM+hLsHUqB+NhOlifiOkENAIG4RV2BFWVGTATVzbXoR8L0EgNWpiriPaeIjBCS5B9PTtkaxQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.3.tgz",
+            "integrity": "sha512-SOux4+jikCnOwoJvpBp/grOqzFmJPnNSwe3sAg1Bn93YdmCiDtvolZifJIhiRq0UWMTnLRPj9/ZCMAc2W9VsMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.3.tgz",
+            "integrity": "sha512-HE+ejy9dX9JP3yLL6CGYoWym4Cted1lGXH7DxsbNDGiq8KabwVR7mzYidwsyNZ/m0hNWjiS+dzSwrsgMB/OIaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.3.tgz",
+            "integrity": "sha512-v5Oa6p7hCT3ONqYHQyTFQYcycD06eMhHbr0m7evpvPQSpWJIq8GgbdnvA9bVGTUlOx6KOeDrX7Z0W4s/yboNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@peculiar/x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1928,6 +2195,28 @@
             "dependencies": {
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -2086,16 +2375,6 @@
                 "undici-types": "~8.3.0"
             }
         },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -2118,9 +2397,9 @@
             "license": "MIT"
         },
         "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true,
             "license": "MIT"
         },
@@ -2445,6 +2724,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
+            }
+        },
         "node_modules/adjust-sourcemap-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -2606,6 +2898,28 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
         "node_modules/assert": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
@@ -2630,6 +2944,13 @@
             "dependencies": {
                 "inherits": "2.0.1"
             }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/autoprefixer": {
             "version": "10.5.4",
@@ -2668,13 +2989,32 @@
                 "postcss": "^8.1.0"
             }
         },
-        "node_modules/axios": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.10.0"
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/axios": {
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.33.0.tgz",
+            "integrity": "sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.4",
+                "form-data": "^4.0.4",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/babel-loader": {
@@ -2820,10 +3160,11 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-            "dev": true
+            "version": "4.12.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+            "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "1.20.6",
@@ -2953,29 +3294,119 @@
             }
         },
         "node_modules/browserify-rsa": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+            "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "^5.2.1",
+                "randombytes": "^2.1.0",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
-        "node_modules/browserify-sign": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+        "node_modules/browserify-rsa/node_modules/bn.js": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+            "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-rsa/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+            "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+            "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "^5.2.3",
+                "browserify-rsa": "^4.1.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.6.1",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.9",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
+        },
+        "node_modules/browserify-sign/node_modules/bn.js": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+            "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/browserify-sign/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/browserify-zlib": {
             "version": "0.2.0",
@@ -3050,6 +3481,22 @@
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3058,6 +3505,35 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -3201,14 +3677,40 @@
             }
         },
         "node_modules/cipher-base": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+            "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
+        },
+        "node_modules/cipher-base/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/clean-css": {
             "version": "5.3.3",
@@ -3288,6 +3790,19 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/commander": {
             "version": "7.2.0",
@@ -3913,27 +4428,75 @@
                 }
             }
         },
-        "node_modules/default-gateway": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+        "node_modules/default-browser": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "execa": "^5.0.0"
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/depd": {
@@ -4177,10 +4740,11 @@
             "license": "ISC"
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
                 "brorand": "^1.1.0",
@@ -4190,12 +4754,6 @@
                 "minimalistic-assert": "^1.0.1",
                 "minimalistic-crypto-utils": "^1.0.1"
             }
-        },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -4310,6 +4868,22 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4419,30 +4993,6 @@
             "dependencies": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
-            }
-        },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
         "node_modules/express": {
@@ -4561,9 +5111,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -4777,9 +5327,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.8",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-            "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "dev": true,
             "funding": [
                 {
@@ -4787,6 +5337,7 @@
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -4794,6 +5345,39 @@
                 "debug": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -4844,13 +5428,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/fs-monkey": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-            "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-            "dev": true,
-            "license": "Unlicense"
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -4942,19 +5519,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4989,6 +5553,13 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/globby": {
             "version": "10.0.2",
@@ -5044,12 +5615,41 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5154,23 +5754,6 @@
                 "readable-stream": "^2.0.1",
                 "wbuf": "^1.1.0"
             }
-        },
-        "node_modules/html-entities": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/mdevils"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://patreon.com/mdevils"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/html-loader": {
             "version": "1.3.2",
@@ -5403,14 +5986,14 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
             "dev": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "engines": {
-                "node": ">=10.17.0"
+                "node": ">=10.18"
             }
         },
         "node_modules/iconv-lite": {
@@ -5590,6 +6173,19 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.2",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -5653,6 +6249,54 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+            "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5688,17 +6332,20 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">= 0.4"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-wsl": {
@@ -6044,11 +6691,26 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -6056,18 +6718,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/locate-path": {
@@ -6084,10 +6734,11 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -6214,17 +6865,520 @@
             }
         },
         "node_modules/memfs": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-            "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+            "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
             "dev": true,
-            "license": "Unlicense",
+            "license": "Apache-2.0",
             "dependencies": {
-                "fs-monkey": "^1.0.4"
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/buffers": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+            "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
             },
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
             }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+            "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+            "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+            "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+            "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+            "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "glob-to-regex.js": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+            "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+            "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/thingies": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "node_modules/memfs/node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.3",
@@ -6336,16 +7490,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/mini-css-extract-plugin": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
@@ -6437,130 +7581,6 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "dev": true
-        },
-        "node_modules/minimizer-webpack-plugin": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@minify-html/node": {
-                    "optional": true
-                },
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/css": {
-                    "optional": true
-                },
-                "@swc/html": {
-                    "optional": true
-                },
-                "clean-css": {
-                    "optional": true
-                },
-                "cssnano": {
-                    "optional": true
-                },
-                "csso": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "html-minifier-terser": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "postcss": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6635,16 +7655,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
-        },
-        "node_modules/node-forge": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
         },
         "node_modules/node-libs-browser": {
             "version": "2.2.1",
@@ -6730,19 +7740,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -6817,35 +7814,20 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6900,17 +7882,21 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/retry": "0.12.0",
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -6961,18 +7947,42 @@
             }
         },
         "node_modules/parse-asn1": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-            "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+            "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3",
-                "safe-buffer": "^5.1.1"
+                "asn1.js": "^4.10.1",
+                "browserify-aes": "^1.2.0",
+                "evp_bytestokey": "^1.0.3",
+                "pbkdf2": "^3.1.5",
+                "safe-buffer": "^5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
+        },
+        "node_modules/parse-asn1/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -7080,20 +8090,96 @@
             }
         },
         "node_modules/pbkdf2": {
-            "version": "3.0.17",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-            "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+            "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "^2.0.3",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.12",
+                "to-buffer": "^1.2.2"
             },
             "engines": {
-                "node": ">=0.12"
+                "node": ">= 0.10"
             }
+        },
+        "node_modules/pbkdf2/node_modules/hash-base": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+            "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^2.3.8",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/readable-stream": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/readable-stream/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pbkdf2/node_modules/ripemd160": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+            "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hash-base": "^3.1.2",
+                "inherits": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -7126,6 +8212,41 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/pkijs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/postcss": {
@@ -7803,6 +8924,13 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -7824,6 +8952,33 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/pvutils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+            "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/qs": {
@@ -7968,6 +9123,13 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -8189,23 +9351,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/ripemd160": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -8214,6 +9359,19 @@
             "dependencies": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -8349,17 +9507,17 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -8510,6 +9668,24 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -8524,17 +9700,46 @@
             "license": "ISC"
         },
         "node_modules/sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "dev": true,
+            "license": "(MIT AND BSD-3-Clause)",
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             },
             "bin": {
                 "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/sha.js/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
@@ -8664,13 +9869,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/slash": {
             "version": "3.0.0",
@@ -8861,16 +10059,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/style-loader": {
@@ -9173,6 +10361,49 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/to-buffer/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9202,6 +10433,19 @@
             "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
             "dev": true
         },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -9220,6 +10464,21 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/undici-types": {
@@ -9381,14 +10640,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vary": {
@@ -9442,32 +10704,37 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.109.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.1.tgz",
-            "integrity": "sha512-Q4XQscWSLNQSaMFsIWUZ+IVpvwLqD+MvjIuSQC1hG8m1ZMK78VAsNMhTjD3icJelypp6aM5Hq8BZNEX3sc1PJw==",
+            "version": "5.104.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.2",
-                "es-module-lexer": "^2.1.0",
+                "enhanced-resolve": "^5.17.4",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.6.1",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.3.1",
+                "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -9534,27 +10801,33 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
@@ -9594,6 +10867,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -9615,55 +10905,53 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.25",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "default-gateway": "^6.0.3",
-                "express": "^4.17.3",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.14.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.4",
-                "ws": "^8.13.0"
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -9672,6 +10960,19 @@
                 "webpack-cli": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/webpack-dev-server/node_modules/ajv": {
@@ -9977,6 +11278,28 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-typed-array": {
+            "version": "1.1.22",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/wildcard": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -10064,6 +11387,38 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/xtend": {

--- a/notas/package.json
+++ b/notas/package.json
@@ -10,12 +10,27 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "axios": "^0.21",
+        "axios": "^0.33",
         "cross-env": "^7.0",
         "laravel-mix": "^6.0.49",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.15.2",
-        "sass-loader": "^8.0.0"
+        "sass-loader": "^8.0.0",
+        "webpack": "5.104.1"
+    },
+    "overrides": {
+        "webpack-dev-server": "^5.2.6",
+        "json5": "^2.2.3",
+        "loader-utils": "^1.4.2",
+        "fast-uri": "^3.1.5",
+        "uuid": "^11.1.1",
+        "browserify-sign": "^4.2.2",
+        "cipher-base": "^1.0.5",
+        "elliptic": "^6.6.1",
+        "pbkdf2": "^3.1.3",
+        "sha.js": "^2.4.12",
+        "follow-redirects": "^1.16.0",
+        "bn.js": "^4.12.3"
     }
 }

--- a/notas_auth/package-lock.json
+++ b/notas_auth/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "dependabot_20260728-909-c1azhq",
+    "name": "notas_auth",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -10,12 +10,13 @@
                 "cross-env": "^7.0",
                 "jquery": "^3.2",
                 "laravel-mix": "^6.0.49",
-                "lodash": "^4.18.1",
+                "lodash": "^4.18.0",
                 "popper.js": "^1.12",
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.15.2",
                 "sass-loader": "^8.0.0",
-                "vue-template-compiler": "^2.6.11"
+                "vue-template-compiler": "^2.6.11",
+                "webpack": "5.104.1"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1798,6 +1799,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@noble/hashes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+            "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1835,6 +1849,259 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@peculiar/asn1-cms": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.9.3.tgz",
+            "integrity": "sha512-N3POfw5RA7efAliAATiudtmvKQqukVEOzrMQuqQY/us2EPKczMy2WiecLt1SX6s3b0OwcFaPUXGF6uIYlBUTbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-cms/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-csr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.9.3.tgz",
+            "integrity": "sha512-E9zYmC5mk7eiDKqQAOsZGrJ7mUCIDC0031s4Nsl7dj1Za5EBKcHVqY+1vD/a4xbk480PGqvi455W2b4FeHRJ8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-csr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-ecc": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.9.3.tgz",
+            "integrity": "sha512-4xmeZiZ46VI2qGbiZPzdv6p9IhMtjWdbwZf3VCgN8OAVcued60ej5Ki2FF94srVH4Ot/h45Co7T5C/fpQXP4rA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-ecc/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pfx": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.9.3.tgz",
+            "integrity": "sha512-Nzwoj+fRr1XB9CQuc4AanUuvQ3OIXAY+ngZIYP+eZUqd+Sonj+ZHTnrg+egQuUJ64/iMi9HFPN04MokGrFTK0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-rsa": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pfx/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs8": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.9.3.tgz",
+            "integrity": "sha512-ecGZpkY6Lq5bSgTFU+LS74WjawzDgjWHcjFMVNPH/1C0j53Xi9dmLcPMdmZyk8gdsd2RKeV1fP9EbLB6W6zZ1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs8/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-pkcs9": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.9.3.tgz",
+            "integrity": "sha512-yjWVrQEmPp2y9lWjLLE28BRHbt7wYdwWvwXjFgNuekP9mDD/ofz31muVI8qOg2as7XZs1bZIZGPPnJ/0osTClQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.9.3",
+                "@peculiar/asn1-pfx": "^2.9.3",
+                "@peculiar/asn1-pkcs8": "^2.9.3",
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "@peculiar/asn1-x509-attr": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-pkcs9/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-rsa": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.9.3.tgz",
+            "integrity": "sha512-t7m3e9p/Gf9YoMM+hLsHUqB+NhOlifiOkENAIG4RV2BFWVGTATVzbXoR8L0EgNWpiriPaeIjBCS5B9PTtkaxQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-rsa/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-schema": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.3.tgz",
+            "integrity": "sha512-SOux4+jikCnOwoJvpBp/grOqzFmJPnNSwe3sAg1Bn93YdmCiDtvolZifJIhiRq0UWMTnLRPj9/ZCMAc2W9VsMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.9.3.tgz",
+            "integrity": "sha512-HE+ejy9dX9JP3yLL6CGYoWym4Cted1lGXH7DxsbNDGiq8KabwVR7mzYidwsyNZ/m0hNWjiS+dzSwrsgMB/OIaQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/utils": "^2.0.2",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.9.3.tgz",
+            "integrity": "sha512-v5Oa6p7hCT3ONqYHQyTFQYcycD06eMhHbr0m7evpvPQSpWJIq8GgbdnvA9bVGTUlOx6KOeDrX7Z0W4s/yboNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-schema": "^2.9.3",
+                "@peculiar/asn1-x509": "^2.9.3",
+                "asn1js": "^3.0.10",
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/asn1-x509-attr/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/asn1-x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/utils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+            "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@peculiar/utils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/@peculiar/x509": {
+            "version": "1.14.3",
+            "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+            "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@peculiar/asn1-cms": "^2.6.0",
+                "@peculiar/asn1-csr": "^2.6.0",
+                "@peculiar/asn1-ecc": "^2.6.0",
+                "@peculiar/asn1-pkcs9": "^2.6.0",
+                "@peculiar/asn1-rsa": "^2.6.0",
+                "@peculiar/asn1-schema": "^2.6.0",
+                "@peculiar/asn1-x509": "^2.6.0",
+                "pvtsutils": "^1.3.6",
+                "reflect-metadata": "^0.2.2",
+                "tslib": "^2.8.1",
+                "tsyringe": "^4.10.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@peculiar/x509/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -1932,6 +2199,28 @@
             "dependencies": {
                 "@types/express-serve-static-core": "*",
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/eslint": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -2090,16 +2379,6 @@
                 "undici-types": "~8.3.0"
             }
         },
-        "node_modules/@types/node-forge": {
-            "version": "1.3.14",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-            "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -2122,9 +2401,9 @@
             "license": "MIT"
         },
         "node_modules/@types/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true,
             "license": "MIT"
         },
@@ -2449,6 +2728,19 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
+            }
+        },
         "node_modules/adjust-sourcemap-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz",
@@ -2609,6 +2901,28 @@
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/assert": {
             "version": "1.5.0",
@@ -2850,10 +3164,11 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-            "dev": true
+            "version": "4.12.5",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+            "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "1.20.6",
@@ -3165,6 +3480,22 @@
             "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
             "dev": true
         },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/bytes": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3173,6 +3504,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/bytestreamjs": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+            "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/call-bind": {
@@ -4092,17 +4433,34 @@
                 }
             }
         },
-        "node_modules/default-gateway": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-            "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+        "node_modules/default-browser": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "dependencies": {
-                "execa": "^5.0.0"
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/define-data-property": {
@@ -4124,13 +4482,16 @@
             }
         },
         "node_modules/define-lazy-prop": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/delayed-stream": {
@@ -4399,12 +4760,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -4645,30 +5000,6 @@
                 "safe-buffer": "^5.1.1"
             }
         },
-        "node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
         "node_modules/express": {
             "version": "4.22.2",
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -4785,9 +5116,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -5103,13 +5434,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/fs-monkey": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-            "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-            "dev": true,
-            "license": "Unlicense"
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5200,19 +5524,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5247,6 +5558,13 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/globby": {
             "version": "10.0.2",
@@ -5443,23 +5761,6 @@
                 "readable-stream": "^2.0.1",
                 "wbuf": "^1.1.0"
             }
-        },
-        "node_modules/html-entities": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-            "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/mdevils"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://patreon.com/mdevils"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/html-loader": {
             "version": "1.3.2",
@@ -5692,14 +5993,14 @@
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
         },
-        "node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
             "dev": true,
-            "license": "Apache-2.0",
+            "license": "MIT",
             "engines": {
-                "node": ">=10.17.0"
+                "node": ">=10.18"
             }
         },
         "node_modules/iconv-lite": {
@@ -5955,6 +6256,54 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-inside-container/node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-network-error": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+            "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5988,19 +6337,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-typed-array": {
@@ -6368,11 +6704,26 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/loader-utils": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+        "node_modules/loader-runner": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+            "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -6380,18 +6731,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/loader-utils/node_modules/json5": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-            "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-            "dev": true,
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
-            "bin": {
-                "json5": "lib/cli.js"
             }
         },
         "node_modules/locate-path": {
@@ -6539,17 +6878,520 @@
             }
         },
         "node_modules/memfs": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-            "integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.68.1.tgz",
+            "integrity": "sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==",
             "dev": true,
-            "license": "Unlicense",
+            "license": "Apache-2.0",
             "dependencies": {
-                "fs-monkey": "^1.0.4"
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-to-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/buffers": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.68.1.tgz",
+            "integrity": "sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
             },
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
             }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.68.1.tgz",
+            "integrity": "sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.68.1.tgz",
+            "integrity": "sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/fs-print": "4.68.1",
+                "@jsonjoy.com/fs-snapshot": "4.68.1",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.68.1.tgz",
+            "integrity": "sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.68.1.tgz",
+            "integrity": "sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.68.1",
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "@jsonjoy.com/fs-node-utils": "4.68.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.68.1.tgz",
+            "integrity": "sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.68.1",
+                "glob-to-regex.js": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.68.1.tgz",
+            "integrity": "sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.68.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.68.1.tgz",
+            "integrity": "sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.68.1",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/thingies": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.1.tgz",
+            "integrity": "sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
+            }
+        },
+        "node_modules/memfs/node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/memfs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.3",
@@ -6661,16 +7503,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/mini-css-extract-plugin": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
@@ -6762,130 +7594,6 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "dev": true
-        },
-        "node_modules/minimizer-webpack-plugin": {
-            "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
-            "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.25",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^4.3.0",
-                "terser": "^5.31.1"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^5.1.0"
-            },
-            "peerDependenciesMeta": {
-                "@minify-html/node": {
-                    "optional": true
-                },
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/css": {
-                    "optional": true
-                },
-                "@swc/html": {
-                    "optional": true
-                },
-                "clean-css": {
-                    "optional": true
-                },
-                "cssnano": {
-                    "optional": true
-                },
-                "csso": {
-                    "optional": true
-                },
-                "esbuild": {
-                    "optional": true
-                },
-                "html-minifier-terser": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "postcss": {
-                    "optional": true
-                },
-                "uglify-js": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/ajv-keywords": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3"
-            },
-            "peerDependencies": {
-                "ajv": "^8.8.2"
-            }
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/minimizer-webpack-plugin/node_modules/schema-utils": {
-            "version": "4.3.3",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/json-schema": "^7.0.9",
-                "ajv": "^8.9.0",
-                "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6960,16 +7668,6 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
-        },
-        "node_modules/node-forge": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-            "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-            "dev": true,
-            "license": "(BSD-3-Clause OR GPL-2.0)",
-            "engines": {
-                "node": ">= 6.13.0"
-            }
         },
         "node_modules/node-libs-browser": {
             "version": "2.2.1",
@@ -7055,19 +7753,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -7142,35 +7827,20 @@
                 "wrappy": "1"
             }
         },
-        "node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/open": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "define-lazy-prop": "^2.0.0",
-                "is-docker": "^2.1.1",
-                "is-wsl": "^2.2.0"
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7225,17 +7895,21 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/retry": "0.12.0",
+                "@types/retry": "0.12.2",
+                "is-network-error": "^1.0.0",
                 "retry": "^0.13.1"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/p-try": {
@@ -7499,6 +8173,31 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/pkijs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+            "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@noble/hashes": "1.4.0",
+                "asn1js": "^3.0.6",
+                "bytestreamjs": "^2.0.1",
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/pkijs/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
         },
         "node_modules/popper.js": {
             "version": "1.16.1",
@@ -8226,6 +8925,33 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/pvutils": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+            "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/qs": {
             "version": "6.15.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -8369,6 +9095,13 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+            "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -8590,23 +9323,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/ripemd160": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
@@ -8619,6 +9335,19 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-parallel": {
@@ -8754,17 +9483,17 @@
             "license": "MIT"
         },
         "node_modules/selfsigned": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+            "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/node-forge": "^1.3.0",
-                "node-forge": "^1"
+                "@peculiar/x509": "^1.14.2",
+                "pkijs": "^3.3.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/semver": {
@@ -9117,13 +9846,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -9313,16 +10035,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/style-loader": {
@@ -9697,6 +10409,19 @@
             "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
             "dev": true
         },
+        "node_modules/tsyringe": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+            "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -9891,14 +10616,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vary": {
@@ -9962,32 +10690,37 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.109.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.1.tgz",
-            "integrity": "sha512-Q4XQscWSLNQSaMFsIWUZ+IVpvwLqD+MvjIuSQC1hG8m1ZMK78VAsNMhTjD3icJelypp6aM5Hq8BZNEX3sc1PJw==",
+            "version": "5.104.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
+            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.16.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.2",
-                "es-module-lexer": "^2.1.0",
+                "enhanced-resolve": "^5.17.4",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
-                "mime-db": "^1.54.0",
-                "minimizer-webpack-plugin": "^5.6.1",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.3.1",
+                "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
-                "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.1"
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.4.4",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -10054,27 +10787,33 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.3",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
+                "webpack": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "webpack": {
+                    "optional": true
+                }
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
@@ -10114,6 +10853,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -10135,55 +10891,53 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.15.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-            "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+            "version": "5.2.6",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+            "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/bonjour": "^3.5.9",
-                "@types/connect-history-api-fallback": "^1.3.5",
-                "@types/express": "^4.17.13",
-                "@types/serve-index": "^1.9.1",
-                "@types/serve-static": "^1.13.10",
-                "@types/sockjs": "^0.3.33",
-                "@types/ws": "^8.5.5",
+                "@types/bonjour": "^3.5.13",
+                "@types/connect-history-api-fallback": "^1.5.4",
+                "@types/express": "^4.17.25",
+                "@types/express-serve-static-core": "^4.17.21",
+                "@types/serve-index": "^1.9.4",
+                "@types/serve-static": "^1.15.5",
+                "@types/sockjs": "^0.3.36",
+                "@types/ws": "^8.5.10",
                 "ansi-html-community": "^0.0.8",
-                "bonjour-service": "^1.0.11",
-                "chokidar": "^3.5.3",
+                "bonjour-service": "^1.2.1",
+                "chokidar": "^3.6.0",
                 "colorette": "^2.0.10",
-                "compression": "^1.7.4",
+                "compression": "^1.8.1",
                 "connect-history-api-fallback": "^2.0.0",
-                "default-gateway": "^6.0.3",
-                "express": "^4.17.3",
+                "express": "^4.22.1",
                 "graceful-fs": "^4.2.6",
-                "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.3",
-                "ipaddr.js": "^2.0.1",
-                "launch-editor": "^2.6.0",
-                "open": "^8.0.9",
-                "p-retry": "^4.5.0",
-                "rimraf": "^3.0.2",
-                "schema-utils": "^4.0.0",
-                "selfsigned": "^2.1.1",
+                "http-proxy-middleware": "^2.0.9",
+                "ipaddr.js": "^2.1.0",
+                "launch-editor": "^2.14.1",
+                "open": "^10.0.3",
+                "p-retry": "^6.2.0",
+                "schema-utils": "^4.2.0",
+                "selfsigned": "^5.5.0",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.24",
                 "spdy": "^4.0.2",
-                "webpack-dev-middleware": "^5.3.4",
-                "ws": "^8.13.0"
+                "webpack-dev-middleware": "^7.4.2",
+                "ws": "^8.18.0"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
             },
             "engines": {
-                "node": ">= 12.13.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             },
             "peerDependencies": {
-                "webpack": "^4.37.0 || ^5.0.0"
+                "webpack": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "webpack": {
@@ -10192,6 +10946,19 @@
                 "webpack-cli": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+            "version": "4.19.9",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+            "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/webpack-dev-server/node_modules/ajv": {
@@ -10606,6 +11373,38 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/wsl-utils/node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/xtend": {

--- a/notas_auth/package.json
+++ b/notas_auth/package.json
@@ -15,11 +15,21 @@
         "cross-env": "^7.0",
         "jquery": "^3.2",
         "laravel-mix": "^6.0.49",
-        "lodash": "^4.18.1",
+        "lodash": "^4.18.0",
         "popper.js": "^1.12",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.15.2",
         "sass-loader": "^8.0.0",
-        "vue-template-compiler": "^2.6.11"
+        "vue-template-compiler": "^2.6.11",
+        "webpack": "5.104.1"
+    },
+    "overrides": {
+        "webpack-dev-server": "^5.2.6",
+        "json5": "^2.2.3",
+        "loader-utils": "^1.4.2",
+        "fast-uri": "^3.1.5",
+        "uuid": "^11.1.1",
+        "elliptic": "^6.6.1",
+        "bn.js": "^4.12.3"
     }
 }


### PR DESCRIPTION
Ninguna tenía un PR de Dependabot propio abierto. Además, las tres ya
estaban en webpack 5.109.1, que rompe la build de producción: laravel-mix
6.0.49 (última versión publicada de esa serie) importa directo
`webpack/lib/SizeFormatHelpers`, un módulo interno que webpack eliminó entre
5.105.0 y 5.107.0. Nadie lo notó porque el repo no tiene CI.

Se fija webpack a 5.104.1 (la última compatible y ya dentro de las versiones
que corrigen la alerta de seguridad correspondiente), y se agregan overrides
(este repo usa npm, no yarn) para las dependencias transitivas sin PR propio:
cipher-base, elliptic, pbkdf2, sha.js, browserify-sign, bn.js, uuid,
webpack-dev-server, json5, loader-utils, fast-uri, follow-redirects. axios y
lodash son dependencias directas, se bumpean directo.

vue-template-compiler (notas_auth, libros) queda sin arreglo: la alerta no
tiene versión parcheada en la serie 2.x, que es la que exige Vue 2.

Verificado en las tres: `npx mix --production` compila.
